### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="pipelineinfrastructure",
+    name="PipelineInfrastructure",
     version="0.0.1",
     url="https://github.com/AfricasVoices/Pipeline-Infrastructure",
     


### PR DESCRIPTION
This is broadly how setup.py should look for this project.

Before it can be imported with pipenv, we will need to replace the Pipfile-s in the other outstanding PRs with an __init_.py file in each folder and move their dependencies in setup.py. We will also need to create a release to match the version number in setup.py.