### PR TITLE
Update drive client wrapper to work with service account and shared folders

### DIFF
--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -125,7 +125,8 @@ def _add_folder(name, parent_id):
     log.info('Creating folder "{}" under parent with id "{}"...'.format(name, parent_id))
     file_metadata = {
         'name': name,
-        'mimeType': 'application/vnd.google-apps.folder'
+        'mimeType': 'application/vnd.google-apps.folder',
+        'parents': [parent_id],
     }
     file = _drive_service.files().create(body=file_metadata,
                                         fields='id').execute()

--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -75,8 +75,11 @@ def _get_folder_id(name, parent_id, recursive=False):
     if (len(files) > 1):
         log.error('Multiple folders with name "{}" found under parent with id {}.'.format(name, parent_id))
         exit(1)
-    log.info('Getting id of folder "{}" under parent with id "{}" - done. Folder id is "{}"'.format(name, parent_id, files[0].get('id')))
-    return files[0].get('id')
+    assert(len(files) == 1)
+    folder = files[0]
+    folder_id = folder.get('id')
+    log.info('Getting id of folder "{}" under parent with id "{}" - done. Folder id is "{}"'.format(name, parent_id, folder_id))
+    return folder_id
 
 def _get_shared_folder_id(name):
     log.info('Getting id of shared-with-me folder "{}"...'.format(name))
@@ -91,8 +94,11 @@ def _get_shared_folder_id(name):
     if (len(files) > 1):
         log.error('Multiple folders with name "{}" found in shared-with-me category.'.format(name))
         exit(1)
-    log.info('Getting id of shared-with-me folder "{}" - done. Folder id is "{}"'.format(name, files[0].get('id')))
-    return files[0].get('id')
+    assert(len(files) == 1)
+    folder = files[0]
+    folder_id = folder.get('id')
+    log.info('Getting id of shared-with-me folder "{}" - done. Folder id is "{}"'.format(name, folder_id))
+    return folder_id
 
 
 def _get_path_id(path, recursive=False, target_folder_is_shared_with_me=False):

--- a/storage/google_drive/upload.py
+++ b/storage/google_drive/upload.py
@@ -2,18 +2,17 @@ import drive_client_wrapper as dcw
 
 import sys
 
-if (len(sys.argv) != 5):
-    print ("Usage python upload.py auth_credentials auth_token file_to_upload to_drive_folder_path")
-    print ("Uploads a new file to Google Drive under the specified path, replacing")
-    print ("the file with the same name if it exists")
+if (len(sys.argv) != 4):
+    print ("Usage python upload.py service_account_credentials_file file_to_upload to_drive_folder_path")
+    print ("Example script for uploads a file to Google Drive under the specified path, replacing")
+    print ("the file with the same name if it exists.")
 
     exit(1)
 
-AUTH_CREDENTIALS = sys.argv[1]
-AUTH_TOKEN = sys.argv[2]
-dcw.init_client(AUTH_CREDENTIALS, AUTH_TOKEN)
+SERVICE_ACCOUNT_CREDENTIALS_FILE = sys.argv[1]
+dcw.init_client(SERVICE_ACCOUNT_CREDENTIALS_FILE)
 
-FILE_TO_UPLOAD = sys.argv[3]
-DRIVE_FOLDER_PATH = sys.argv[4]
+FILE_TO_UPLOAD = sys.argv[2]
+DRIVE_FOLDER_PATH = sys.argv[3]
 
-dcw.update_or_create(FILE_TO_UPLOAD, DRIVE_FOLDER_PATH, recursive=True)
+dcw.update_or_create(FILE_TO_UPLOAD, DRIVE_FOLDER_PATH, recursive=True, target_folder_is_shared_with_me=True)


### PR DESCRIPTION
I've added for now a param to update_or_create as to whether it should search in the drive root or shared folders - but I'm not 100% it's the right thing to do. Given that it's a service account, should it attempt to always find the shared folder to write in rather than default to writing in the root of My Drive?