### PR TITLE
Minimum fix to timeout

### DIFF
--- a/id_infrastructure/firestore_uuid_table.py
+++ b/id_infrastructure/firestore_uuid_table.py
@@ -121,6 +121,12 @@ class FirestoreUuidTable(object):
         batch_counter = 0
         batch = self._client.batch()
         for data in new_mappings.keys():
+
+            # ensure in single read that the data doesn't exist
+            uuid_doc_ref = self._client.document(f"tables/{self._table_name}/mappings/{data}").get()
+            exists = uuid_doc_ref.exists
+            assert not exists, "Attempt to set mapping for data, which was already in the datastore"
+            
             i += 1
             batch.set(
                 self._client.document(f"tables/{self._table_name}/mappings/{data}"),

--- a/id_infrastructure/firestore_uuid_table.py
+++ b/id_infrastructure/firestore_uuid_table.py
@@ -127,7 +127,7 @@ class FirestoreUuidTable(object):
             # ensure in single read that the data doesn't exist
             uuid_doc = self._client.document(f"tables/{self._table_name}/mappings/{data}").get()
             exists = uuid_doc.exists
-            assert not exists, "Attempt to set mapping for data, which was already in the datastore"
+            assert not exists, "Attempt to set mapping for data which was already in the datastore"
             
             i += 1
             batch.set(

--- a/id_infrastructure/firestore_uuid_table.py
+++ b/id_infrastructure/firestore_uuid_table.py
@@ -124,10 +124,9 @@ class FirestoreUuidTable(object):
         batch_counter = 0
         batch = self._client.batch()
         for data in new_mappings.keys():
-
             # ensure in single read that the data doesn't exist
-            uuid_doc_ref = self._client.document(f"tables/{self._table_name}/mappings/{data}").get()
-            exists = uuid_doc_ref.exists
+            uuid_doc = self._client.document(f"tables/{self._table_name}/mappings/{data}").get()
+            exists = uuid_doc.exists
             assert not exists, "Attempt to set mapping for data, which was already in the datastore"
             
             i += 1

--- a/id_infrastructure/firestore_uuid_table.py
+++ b/id_infrastructure/firestore_uuid_table.py
@@ -32,6 +32,9 @@ class FirestoreUuidTable(object):
         :param updated_mappings: Mappings from data to uuids
         :type updated_mappings: dict of str -> str
         """
+
+        assert "Not safe to use as not yet protected against readtimeouts"
+
         log.info(f"Updating {len(updated_mappings)} mappings...")
 
         # Ensure that the requested uuids are in the correct format for this table


### PR DESCRIPTION
@as2388 I think this is the simplest way of protecting against the partial read bug.

Testing: Introduce an import of time, and add a line at currently ln 107 with time.sleep(60) to simulate a read timeout. Without this, it will work and overwrite data, with it, it will crash on the assert

I don't think `update_data_to_uuid_mappings` is safe to use yet - but I think it is only used by the migration tool, not the pipeline?

`data_to_uuid` which is the other place that updates the mapping is already protected by an existence check

Please feel free to merge or adapt