### PR TITLE
Handle HTTP 500 errors in Drive upload by retrying

### DIFF
--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -229,5 +229,5 @@ def update_or_create(source_file_path, target_folder_path, target_file_name=None
             update_or_create(source_file_path, target_folder_path, target_file_name, recursive,
                              target_folder_is_shared_with_me, max_retries - 1, backoff_seconds * 2)
         else:
-            log.warning("Retried the maximum number of times")
+            log.error("Retried the maximum number of times")
             raise ex

--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -218,13 +218,13 @@ def update_or_create(source_file_path, target_folder_path, target_file_name=None
 
         _create_file(source_file_path, target_folder_id, target_file_name)
     except HttpError as ex:
-        # Handle 500 errors with exponentiated back-off, as recommended by the Drive docs for this error.
+        # Handle 500 errors with exponentiated back-off, as is recommended by the Drive docs for this error.
         if ex.resp.status != 500:
             raise ex
 
-        log.info(f"Upload failed with HttpError '{ex.error_details}'")
+        log.warning(f"Upload failed with HttpError 500")
         if max_retries > 0:
-            log.info(f"Retrying up to {max_retries} more times, after {backoff_seconds}...")
+            log.info(f"Retrying up to {max_retries} more times, after {backoff_seconds} seconds...")
             time.sleep(backoff_seconds)
             update_or_create(source_file_path, target_folder_path, target_file_name, recursive,
                              target_folder_is_shared_with_me, max_retries - 1, backoff_seconds * 2)


### PR DESCRIPTION
500s from Drive are the most common cause of pipeline failures. This attempts to resolve by automatically retrying failed requests.

This is hard to test due to the randomness of Drive failures. If the code looks good I suggest switching a pipeline to this branch for a day or two and observing if the failure rate changes.