### PR TITLE
Fix connection time out errors in Cloud Storage upload

### DIFF
--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -5,6 +5,8 @@ from core_data_modules.logging import Logger
 
 log = Logger(__name__)
 
+BLOB_CHUNK_SIZE = 10 * 1024 * 1024  # 10 MB
+
 
 def _blob_at_url(storage_client, blob_url):
     parsed_blob_url = urlparse(blob_url)
@@ -52,6 +54,7 @@ def upload_string_to_blob(bucket_credentials_file_path, target_blob_url, string)
     log.info(f"Uploading string to blob '{target_blob_url}' ({len(string)} characters)...")
     storage_client = storage.Client.from_service_account_json(bucket_credentials_file_path)
     blob = _blob_at_url(storage_client, target_blob_url)
+    blob.chunk_size = BLOB_CHUNK_SIZE
     blob.upload_from_string(string)
     log.info("Uploaded string to blob.")
 
@@ -88,5 +91,6 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f):
     log.info(f"Uploading file to blob '{target_blob_url}'...")
     storage_client = storage.Client.from_service_account_json(bucket_credentials_file_path)
     blob = _blob_at_url(storage_client, target_blob_url)
+    blob.chunk_size = BLOB_CHUNK_SIZE
     blob.upload_from_file(f)
     log.info(f"Uploaded file to blob")


### PR DESCRIPTION
Anecdotally I this is the main source of pipeline failures at the moment. When uploading large files, the GCS API breaks the file into 100 MB chunks, and opens a connection to complete each chunk. Connections last 1 minute, so you need to be able to sustain 100MB/minute upload for the duration of your upload, which I suspect Miranda is not always managing at the moment, especially with concurrent pipelines uploading data.

This PR sets the chunk size on uploaded blobs to 10MB. Testing locally on a throttled network connection, this fixes the problem for me. If the code looks good I'd like to test on a pipeline for a day or two and observe if the failure rate does indeed go down in practice before merging.