### PR TITLE
handle http 408 in blob file upload by retrying in small chunk size

### DIFF
--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -96,7 +96,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         log.info(f"Uploaded file to blob")
 
     except ConnectionError or socket.timeout or Timeout as ex:
-        log.warning(f"Failed to upload due to {ex.resp.status} (connection error)")
+        log.warning("Failed to upload due to connection error")
         if max_retries > 0:
             log.info(f"Retrying {max_retries} more times with a reduced chunk_size of 10MiB")
             # lower the chunk size and retry uploading

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -76,7 +76,7 @@ def download_blob_to_file(bucket_credentials_file_path, blob_url, f):
     log.info(f"Downloaded blob to file")
 
 
-def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_retries=3, blob_chunk_size=100.0):
+def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_retries=3, blob_chunk_size=100):
     """
     Uploads a file to a Google Cloud Storage blob.
 
@@ -106,7 +106,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
             # lower the chunk size and start uploading from beginning because resumable_media requires so
             f.seek(0)
             upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,
-                                max_retries - 1, blob_chunk_size/2)
+                                max_retries - 1, blob_chunk_size - 30)
         else:
             log.error(f"Retried 3 times")
             raise ex

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -4,6 +4,7 @@ from google.cloud import storage
 from core_data_modules.logging import Logger
 from requests import ConnectionError, Timeout
 import socket
+import os
 
 log = Logger(__name__)
 
@@ -109,4 +110,5 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
                                 max_retries - 1, blob_chunk_size - 30)
         else:
             log.error(f"Retried 3 times")
+            os.rename(f, f'FAILED_{f}')
             raise ex

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -99,8 +99,9 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         log.warning("Failed to upload due to connection error")
         if max_retries > 0:
             log.info(f"Retrying {max_retries} more times with a reduced chunk_size of 10MiB")
-            # lower the chunk size and start uploading from beginning resumable_media requires so
-            upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f.seek(0),
+            # lower the chunk size and start uploading from beginning because resumable_media requires so
+            f.seek(0)
+            upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,
                                 max_retries - 1, blob_chunk_size=10)
         else:
             log.error(f"Retried 5 times")

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -104,7 +104,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         log.info(f"Uploaded file to blob")
         upload_status = "success"
 
-    except (ConnectionError, socket.timeout, Timeout) as ex:
+    except (ConnectionError, socket.timeout, Timeout):
         log.warning("Failed to upload due to connection error!")
         if max_retries > 0:
             log.info(f"Retrying {max_retries} more times with a reduced chunk_size of {blob_chunk_size - 30}MiB")

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -92,6 +92,9 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
     :param blob_chunk_size: the size of a chunk of data whenever iterating (in MiB).
     :type blob_chunk_size: float
     """
+
+    upload_status = None
+
     try:
         log.info(f"Uploading file to blob '{target_blob_url}'...")
         storage_client = storage.Client.from_service_account_json(bucket_credentials_file_path)
@@ -100,8 +103,6 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         blob.upload_from_file(f)
         log.info(f"Uploaded file to blob")
         upload_status = "success"
-
-        return upload_status
 
     except ConnectionError or socket.timeout or Timeout as ex:
         log.warning("Failed to upload due to connection error!")
@@ -115,4 +116,4 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
             log.error(f"Failed to upload after retrying 3 times!")
             upload_status = "failed"
 
-            return upload_status
+    return upload_status

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -4,7 +4,6 @@ from google.cloud import storage
 from core_data_modules.logging import Logger
 from requests import ConnectionError, Timeout
 import socket
-import os
 
 log = Logger(__name__)
 
@@ -92,9 +91,6 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
     :param blob_chunk_size: the size of a chunk of data whenever iterating (in MiB).
     :type blob_chunk_size: float
     """
-
-    upload_status = None
-
     try:
         log.info(f"Uploading file to blob '{target_blob_url}'...")
         storage_client = storage.Client.from_service_account_json(bucket_credentials_file_path)
@@ -114,6 +110,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
                                 max_retries - 1, blob_chunk_size - 30)
         else:
             log.error(f"Failed to upload after retrying 3 times!")
-            upload_status = "failed"
+
+        upload_status = "failed"
 
     return upload_status

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -99,6 +99,9 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         blob.chunk_size = blob_chunk_size * 1024 * 1024
         blob.upload_from_file(f)
         log.info(f"Uploaded file to blob")
+        upload_status = "success"
+
+        return upload_status
 
     except ConnectionError or socket.timeout or Timeout as ex:
         log.warning("Failed to upload due to connection error")
@@ -110,5 +113,6 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
                                 max_retries - 1, blob_chunk_size - 30)
         else:
             log.error(f"Retried 3 times")
-            os.rename(f.name, f'FAILED_{f.name}')
-            raise ex
+            upload_status = "failed"
+
+            return upload_status

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -110,7 +110,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
             log.error(f"Not retrying because the blob_chunk_size {blob_chunk_size} is below the minimum allowed (256KB)")
             raise ex
 
-        log.info(f"Retrying up to{max_retries} more times with a reduced chunk_size of {blob_chunk_size / 2}KB")
+        log.info(f"Retrying up to {max_retries} more times with a reduced chunk_size of {blob_chunk_size / 2}KB")
         # lower the chunk size and start uploading from beginning because resumable_media requires so
         f.seek(0)
         upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -110,5 +110,5 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
                                 max_retries - 1, blob_chunk_size - 30)
         else:
             log.error(f"Retried 3 times")
-            os.rename(f.name, f'FAILED_{f}')
+            os.rename(f.name, f'FAILED_{f.name}')
             raise ex

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -95,7 +95,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         log.info(f"Uploading file to blob '{target_blob_url}'...")
         storage_client = storage.Client.from_service_account_json(bucket_credentials_file_path)
         blob = _blob_at_url(storage_client, target_blob_url)
-        blob.chunk_size = blob_chunk_size * 1024
+        blob.chunk_size = int(blob_chunk_size * 1024) # resumable expects an integer
         blob.upload_from_file(f)
         log.info(f"Uploaded file to blob")
 

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -77,7 +77,7 @@ def download_blob_to_file(bucket_credentials_file_path, blob_url, f):
     log.info(f"Downloaded blob to file")
 
 
-def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_retries=3, blob_chunk_size=100):
+def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_retries=2, blob_chunk_size=100):
     """
     Uploads a file to a Google Cloud Storage blob.
 

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -108,7 +108,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
     except (ConnectionError, socket.timeout, Timeout) as ex:
         log.warning("Failed to upload due to connection/timeout error")
         if max_retries > 0:
-            log.info(f"Retrying {max_retries} more times with a reduced chunk_size of {blob_chunk_size/2}MiB")
+            log.info(f"Retrying up to{max_retries} more times with a reduced chunk_size of {int(round(blob_chunk_size/2))}MiB")
             # lower the chunk size and start uploading from beginning because resumable_media requires so
             f.seek(0)
             upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -99,8 +99,8 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         log.warning("Failed to upload due to connection error")
         if max_retries > 0:
             log.info(f"Retrying {max_retries} more times with a reduced chunk_size of 10MiB")
-            # lower the chunk size and retry uploading
-            upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,
+            # lower the chunk size and start uploading from beginning resumable_media requires so
+            upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f.seek(0),
                                 max_retries - 1, blob_chunk_size=10)
         else:
             log.error(f"Retried 5 times")

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -110,5 +110,5 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
                                 max_retries - 1, blob_chunk_size - 30)
         else:
             log.error(f"Retried 3 times")
-            os.rename(f, f'FAILED_{f}')
+            os.rename(f.name, f'FAILED_{f}')
             raise ex

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -76,7 +76,7 @@ def download_blob_to_file(bucket_credentials_file_path, blob_url, f):
     log.info(f"Downloaded blob to file")
 
 
-def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_retries=2, blob_chunk_size=100 * 1024):
+def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_retries=4, blob_chunk_size=100 * 1024):
     """
     Uploads a file to a Google Cloud Storage blob.
 

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -98,16 +98,18 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f):
         if ex.resp.status != 408:
             raise ex
 
-        num_retries = 0
-        chunk_sizes= [50, 25, 12.5, 6.25]
-        if num_retries != 5:
+        chunk_sizes = [50, 25, 12.5, 6.25]
+        num_tries = 0
+        if num_tries != 5:
             for chunk_size in chunk_sizes:
                 log.info(f"Retrying to upload file to blob '{target_blob_url}")
                 # lower the chunk size and retry uploading
                 blob.chunk_size = chunk_size * 1024 * 1024
-                blob.upload_from_file(f,)
-                num_retries +=1
-                log.info(f"Uploaded file to blob")
-        else:
-            log.error(f"Retried {num_retries} of times")
+                blob.upload_from_file(f)
+                if ex.resp.status == 200:
+                    log.info(f"Uploaded file to blob")
+                    break
+                num_tries += 1
+        else :
+            log.error(f"Retried 5 times")
             raise ex

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -104,7 +104,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         return upload_status
 
     except ConnectionError or socket.timeout or Timeout as ex:
-        log.warning("Failed to upload due to connection error")
+        log.warning("Failed to upload due to connection error!")
         if max_retries > 0:
             log.info(f"Retrying {max_retries} more times with a reduced chunk_size of {blob_chunk_size - 30}MiB")
             # lower the chunk size and start uploading from beginning because resumable_media requires so
@@ -112,7 +112,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
             upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,
                                 max_retries - 1, blob_chunk_size - 30)
         else:
-            log.error(f"Retried 3 times")
+            log.error(f"Failed to upload after retrying 3 times!")
             upload_status = "failed"
 
             return upload_status

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -104,7 +104,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
         log.info(f"Uploaded file to blob")
         upload_status = "success"
 
-    except ConnectionError or socket.timeout or Timeout as ex:
+    except (ConnectionError, socket.timeout, Timeout) as ex:
         log.warning("Failed to upload due to connection error!")
         if max_retries > 0:
             log.info(f"Retrying {max_retries} more times with a reduced chunk_size of {blob_chunk_size - 30}MiB")

--- a/storage/google_cloud/google_cloud_utils.py
+++ b/storage/google_cloud/google_cloud_utils.py
@@ -102,7 +102,7 @@ def upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f, max_re
     except ConnectionError or socket.timeout or Timeout as ex:
         log.warning("Failed to upload due to connection error")
         if max_retries > 0:
-            log.info(f"Retrying {max_retries} more times with a reduced chunk_size of {blob_chunk_size}MiB")
+            log.info(f"Retrying {max_retries} more times with a reduced chunk_size of {blob_chunk_size - 30}MiB")
             # lower the chunk size and start uploading from beginning because resumable_media requires so
             f.seek(0)
             upload_file_to_blob(bucket_credentials_file_path, target_blob_url, f,


### PR DESCRIPTION
408 request timeout is the most common cause of g cloud file upload failure in the pipelines. This attempts to resolve that by retrying failed requests up to 5 times and halving the chunk_size each time. If the code is okay, we will test this on a pipeline before merging. 
