### PR TITLE
Add drive_client_wrapper.update_or_create_batch

### DIFF
--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -198,7 +198,7 @@ def update_or_create_batch(source_file_paths, target_folder_path, recursive=Fals
     files = _list_folder_id(target_folder_id)
     
     for i, source_file_path in enumerate(source_file_paths):
-        print(f"Uploading file {i}/{len(source_file_paths)}...")
+        log.info(f"Uploading file {i}/{len(source_file_paths)}...")
         
         target_file_name = os.path.basename(source_file_path)
         files_with_upload_name = list(filter(lambda file: file.get('name') == target_file_name, files))

--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -76,7 +76,7 @@ def _list_folder_id(folder_id):
 
 
 def _get_folder_id(name, parent_id, recursive=False):
-    log.info('Getting id of folder "{}" under parent with id "{}"...'.format(name, parent_id))
+    log.info(f"Getting id of folder '{name}' under parent with id '{parent_id}'...")
     response = _drive_service.files().list(
         q=f"name='{name}' and '{parent_id}' in parents and mimeType='{DRIVE_FOLDER_TYPE}'",
         spaces='drive',

--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -193,10 +193,32 @@ def _create_file(source_file_path, target_folder_id, target_file_name=None):
              f"'{source_file_path}' - done. File id is '{file.get('id')}'")
 
 
+def _auto_retry(f, max_retries=2, backoff_seconds=1):
+    try:
+        return f()
+    except (HttpError, socket.timeout) as ex:
+        if type(ex) == HttpError:
+            if ex.resp.status not in {500, 503}:
+                raise ex
+            log.warning(f"Drive call failed with HttpError {ex.resp.status}")
+
+        if type(ex) == socket.timeout:
+            log.warning(f"Drive call failed with socket.timeout error")
+
+        if max_retries > 0:
+            log.info(f"Retrying up to {max_retries} more times, after {backoff_seconds} seconds...")
+            time.sleep(backoff_seconds)
+            _auto_retry(f, max_retries - 1, backoff_seconds * 2)
+        else:
+            log.error("Retried the maximum number of times")
+            raise ex
+
+
 def update_or_create_batch(source_file_paths, target_folder_path, recursive=False,
-                           target_folder_is_shared_with_me=False):
-    target_folder_id = _get_path_id(target_folder_path, recursive, target_folder_is_shared_with_me)
-    files = _list_folder_id(target_folder_id)
+                           target_folder_is_shared_with_me=False, max_retries=2, backoff_seconds=1):
+    target_folder_id = _auto_retry(lambda: _get_path_id(target_folder_path, recursive, target_folder_is_shared_with_me),
+                                   max_retries, backoff_seconds)
+    files = _auto_retry(lambda: _list_folder_id(target_folder_id), max_retries, backoff_seconds)
     
     for i, source_file_path in enumerate(source_file_paths):
         log.info(f"Uploading file {i + 1}/{len(source_file_paths)}...")
@@ -215,51 +237,38 @@ def update_or_create_batch(source_file_paths, target_folder_path, recursive=Fals
             if existing_file.get("mimetype") == "application/vnd.google-apps.folder":
                 log.error(f"Attempting to replace a folder with a file with name '{target_file_name}'")
                 exit(1)
-            _update_file(source_file_path, existing_file.get("id"))
+            _auto_retry(lambda: _update_file(source_file_path, existing_file.get("id")), max_retries, backoff_seconds)
             continue
 
-        _create_file(source_file_path, target_folder_id, target_file_name)
+        _auto_retry(lambda: _create_file(source_file_path, target_folder_id, target_file_name),
+                    max_retries, backoff_seconds)
 
 
 def update_or_create(source_file_path, target_folder_path, target_file_name=None, recursive=False,
                      target_folder_is_shared_with_me=False, max_retries=2, backoff_seconds=1):
-    try:
-        if target_file_name is None:
-            target_file_name = os.path.basename(source_file_path)
+    if target_file_name is None:
+        target_file_name = os.path.basename(source_file_path)
 
-        target_folder_id = _get_path_id(target_folder_path, recursive, target_folder_is_shared_with_me)
-        files = _list_folder_id(target_folder_id)
-        files_with_upload_name = list(filter(lambda file: file.get('name') == target_file_name, files))
+    target_folder_id = _auto_retry(
+        lambda: _get_path_id(target_folder_path, recursive, target_folder_is_shared_with_me),
+        max_retries, backoff_seconds)
+    files = _auto_retry(lambda: _list_folder_id(target_folder_id), max_retries, backoff_seconds)
 
-        if len(files_with_upload_name) > 1:
-            log.error("Multiple files with the same name found in Drive folder.")
-            log.error("I don't know which to update, aborting.")
+    files_with_upload_name = list(filter(lambda file: file.get('name') == target_file_name, files))
+
+    if len(files_with_upload_name) > 1:
+        log.error("Multiple files with the same name found in Drive folder.")
+        log.error("I don't know which to update, aborting.")
+        exit(1)
+
+    if len(files_with_upload_name) == 1:
+        existing_file = files_with_upload_name[0]
+        # Make sure it's not a folder
+        if existing_file.get("mimetype") == "application/vnd.google-apps.folder":
+            log.error(f"Attempting to replace a folder with a file with name '{target_file_name}'")
             exit(1)
+        _auto_retry(lambda: _update_file(source_file_path, existing_file.get("id")), max_retries, backoff_seconds)
+        return
 
-        if len(files_with_upload_name) == 1:
-            existing_file = files_with_upload_name[0]
-            # Make sure it's not a folder
-            if existing_file.get("mimetype") == "application/vnd.google-apps.folder":
-                log.error(f"Attempting to replace a folder with a file with name '{target_file_name}'")
-                exit(1)
-            _update_file(source_file_path, existing_file.get("id"))
-            return
-
-        _create_file(source_file_path, target_folder_id, target_file_name)
-    except (HttpError, socket.timeout) as ex:
-        if type(ex) == HttpError:
-            if ex.resp.status not in {500, 503}:
-                raise ex
-            log.warning(f"Upload failed with HttpError {ex.resp.status}")
-
-        if type(ex) == socket.timeout:
-            log.warning(f"Upload failed with socket.timeout error")
-
-        if max_retries > 0:
-            log.info(f"Retrying up to {max_retries} more times, after {backoff_seconds} seconds...")
-            time.sleep(backoff_seconds)
-            update_or_create(source_file_path, target_folder_path, target_file_name, recursive,
-                             target_folder_is_shared_with_me, max_retries - 1, backoff_seconds * 2)
-        else:
-            log.error("Retried the maximum number of times")
-            raise ex
+    _auto_retry(lambda: _create_file(source_file_path, target_folder_id, target_file_name),
+                max_retries, backoff_seconds)

--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -192,6 +192,34 @@ def _create_file(source_file_path, target_folder_id, target_file_name=None):
              f"'{source_file_path}' - done. File id is '{file.get('id')}'")
 
 
+def update_or_create_batch(source_file_paths, target_folder_path, recursive=False,
+                           target_folder_is_shared_with_me=False):
+    target_folder_id = _get_path_id(target_folder_path, recursive, target_folder_is_shared_with_me)
+    files = _list_folder_id(target_folder_id)
+    
+    for i, source_file_path in enumerate(source_file_paths):
+        print(f"Uploading file {i}/{len(source_file_paths)}...")
+        
+        target_file_name = os.path.basename(source_file_path)
+        files_with_upload_name = list(filter(lambda file: file.get('name') == target_file_name, files))
+
+        if len(files_with_upload_name) > 1:
+            log.error("Multiple files with the same name found in Drive folder.")
+            log.error("I don't know which to update, aborting.")
+            exit(1)
+
+        if len(files_with_upload_name) == 1:
+            existing_file = files_with_upload_name[0]
+            # Make sure it's not a folder
+            if existing_file.get("mimetype") == "application/vnd.google-apps.folder":
+                log.error(f"Attempting to replace a folder with a file with name '{target_file_name}'")
+                exit(1)
+            _update_file(source_file_path, existing_file.get("id"))
+            continue
+
+        _create_file(source_file_path, target_folder_id, target_file_name)
+
+
 def update_or_create(source_file_path, target_folder_path, target_file_name=None, recursive=False,
                      target_folder_is_shared_with_me=False, max_retries=2, backoff_seconds=1):
     try:

--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -198,7 +198,7 @@ def update_or_create_batch(source_file_paths, target_folder_path, recursive=Fals
     files = _list_folder_id(target_folder_id)
     
     for i, source_file_path in enumerate(source_file_paths):
-        log.info(f"Uploading file {i}/{len(source_file_paths)}...")
+        log.info(f"Uploading file {i + 1}/{len(source_file_paths)}...")
         
         target_file_name = os.path.basename(source_file_path)
         files_with_upload_name = list(filter(lambda file: file.get('name') == target_file_name, files))


### PR DESCRIPTION
This adds a function for uploading a list of files to the specified folder in Drive. Using this reduces the number of Drive requests we need to make because we only need to look up the file ids in that directory once per batch, rather than for each file to upload. This should speed up analysis uploads by roughly 1.5-2x (and also leads to shorter, cleaner logging).

I refactored the error handlers into a separate _auto_retry function, which is called multiple times per update_or_create call so that partial uploads don't result in retrying all the files in the batch and so that the probability of failure doesn't increase with the number of files being uploaded.

Apologies for the poor diff, this may be easier to read raw.