### PR TITLE
Automatically fix duplicates on Drive

### DIFF
--- a/storage/google_drive/drive_client_wrapper.py
+++ b/storage/google_drive/drive_client_wrapper.py
@@ -196,7 +196,10 @@ def _create_file(source_file_path, target_folder_id, target_file_name=None):
 
 
 def _delete_file(file_id):
-    log.info(f"Deleting file '{file_id}'...")
+    """
+    Permanently deletes a file, skipping the trash.
+    """
+    log.warning(f"Deleting file '{file_id}'...")
     _drive_service.files().delete(fileId=file_id).execute()
     log.info(f"Deleting file '{file_id}' - done.")
 


### PR DESCRIPTION
Adds a flag 'fix_duplicates' to the upload functions which, if set, automatically handles duplicated files on Drive by removing the duplicates, then uploading again. This will allow us to handle Drive consistency problems automatically rather than needing to manually intervene to delete problematic files, and therefore solves one of the biggest causes of pipeline failures in G&A. 

It's added as a flag which defaults to False because automatically deleting files just because they have the same name is a bit of a scary thing to do in general, but should be fine for pipeline uploads. As an added safety, if the service account attempts to delete files it doesn't own, the delete operation will fail.