### PR TITLE
Update firestore_uuid_table.py to support exporting mapping tables

### DIFF
--- a/id_infrastructure/firestore_uuid_table.py
+++ b/id_infrastructure/firestore_uuid_table.py
@@ -54,7 +54,7 @@ class FirestoreUuidInfrastructure(object):
         :rtype: list of str
         """
         tables = self._client.collection("tables").get()
-        return [t.id for t in tables]
+        return [table.id for table in tables]
 
     def get_table(self, table_name, uuid_prefix):
         """

--- a/id_infrastructure/firestore_uuid_table.py
+++ b/id_infrastructure/firestore_uuid_table.py
@@ -11,6 +11,17 @@ _UUID_KEY_NAME = "uuid"
 log = Logger(__name__)
 
 
+class FirestoreUuidTableCollection(object):
+    def __init__(self, crypto_token_path):
+        cred = credentials.Certificate(crypto_token_path)
+        firebase_admin.initialize_app(cred)
+        self._client = firestore.client()
+
+    def list_table_names(self):
+        tables = self._client.collection("tables").get()
+        return [t.id for t in tables]
+
+
 class FirestoreUuidTable(object):
     """
     Mapping table between a string and a random UUID backed by Firestore
@@ -157,6 +168,10 @@ class FirestoreUuidTable(object):
 
         log.info(f"Found keys for {len(results)} out of {len(uuids_to_lookup)} requests")
         return results
+
+    def get_all_mappings(self):
+        self.data_to_uuid_batch([])
+        return self._mappings_cache.copy()
 
     @staticmethod
     def generate_new_uuid(prefix):


### PR DESCRIPTION
This PR includes the API updates we need to export uuid tables (for the purposes of back-ups and archiving).

These are:
 - The addition of a new FirestoreUuidInfrastructure class for getting and listing the available tables
 - Writes to the table parent doc when data is added, to ensure that the table is visible in collection queries
 - A new get_all_mappings function on uuid tables.
 - Reworked constructors to support multiple table instances being created, and to allow tables to co-exist with other Firestore clients in future. Unfortunately this is a breaking change, as python doesn't support multiple constructors.