### PR TITLE
Write path as str rather than as DocumentReference

### DIFF
--- a/engagement_database/engagement_database.py
+++ b/engagement_database/engagement_database.py
@@ -138,7 +138,7 @@ class EngagementDatabase(object):
 
         # Log a history event for this update
         history_entry = HistoryEntry(
-            update_path=self._message_ref(message.message_id),
+            update_path=self._message_ref(message.message_id).path,
             origin=origin,
             updated_doc=message,
             timestamp=firestore.SERVER_TIMESTAMP


### PR DESCRIPTION
This brings the created object in line with the docstring in the data model itself.