### PR TITLE
Support optional batch fetching in EngagementDatabase.get_messages

### DIFF
--- a/engagement_database/engagement_database.py
+++ b/engagement_database/engagement_database.py
@@ -139,6 +139,9 @@ class EngagementDatabase(object):
         if batch_size is None:
             return messages
 
+        if len(messages) == 0:
+            return []
+
         last_msg = messages[-1]
         while last_msg is not None:
             batch = query.start_after(last_msg.to_dict()).get()

--- a/engagement_database/engagement_database.py
+++ b/engagement_database/engagement_database.py
@@ -123,28 +123,32 @@ class EngagementDatabase(object):
         :type firestore_query_filter: Callable of google.cloud.firestore.Query -> google.cloud.firestore.Query
         :param transaction: Transaction to run this get in or None.
         :type transaction: google.cloud.firestore.Transaction | None
+        :param batch_size: If set, internally fetches the messages in batches of `batch_size`. This allows
+                           `get_messages` to handle datasets larger than what can be downloaded from Firestore within
+                           1 minute, and is recommended for queries that retrieve a large number of documents.
+                           Note that enabling batching may require an additional index to be constructed, and will
+                           slow down very small queries so isn't recommended in all circumstances.
+                           If None, fetches all messages in a single request from Firestore.
+        :type batch_size: int | None
         :return: Messages downloaded from the database.
         :rtype: list of engagement_database.data_models.Message
         """
         messages_ref = self._messages_ref()
         query = firestore_query_filter(messages_ref)
 
-        if batch_size is not None:
-            query = query.order_by("last_updated").order_by("message_id")
-            query = query.limit(batch_size)
+        if batch_size is None:
+            data = query.get(transaction=transaction)
+            return [Message.from_dict(d.to_dict()) for d in data]
+
+        query = query.order_by("last_updated").order_by("message_id")
+        query = query.limit(batch_size)
 
         data = query.get(transaction=transaction)
         messages = [Message.from_dict(d.to_dict()) for d in data]
 
-        if batch_size is None:
-            return messages
-
-        if len(messages) == 0:
-            return []
-
-        last_msg = messages[-1]
+        last_msg = None if len(messages) == 0 else messages[-1]
         while last_msg is not None:
-            batch = query.start_after(last_msg.to_dict()).get()
+            batch = query.start_after(last_msg.to_dict()).get(transaction=transaction)
             messages.extend([Message.from_dict(d.to_dict()) for d in batch])
             last_msg = None if len(batch) == 0 else batch[-1]
         return messages

--- a/engagement_database/engagement_database.py
+++ b/engagement_database/engagement_database.py
@@ -144,7 +144,7 @@ class EngagementDatabase(object):
             batch = query.start_after(last_msg.to_dict()).get()
             messages.extend([Message.from_dict(d.to_dict()) for d in batch])
             last_msg = None if len(batch) == 0 else batch[-1]
-        return messsages
+        return messages
 
     def set_message(self, message, origin, transaction=None):
         """

--- a/engagement_database/engagement_database.py
+++ b/engagement_database/engagement_database.py
@@ -130,6 +130,7 @@ class EngagementDatabase(object):
         query = firestore_query_filter(messages_ref)
 
         if batch_size is not None:
+            query = query.order_by("last_updated").order_by("message_id")
             query = query.limit(batch_size)
 
         data = query.get(transaction=transaction)


### PR DESCRIPTION
We have a couple of places where we need to do large database reads, which requires special batching code to avoid the Firestore connection timing out. This puts that batching into the get_messages function itself, so it will be easy to opt in to it in all the places we need it. 